### PR TITLE
increased maxIdleConns - fix for issue #10

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,39 +1,40 @@
 package main
 
 import (
-    "log"
-    "net/http"
-    "net/http/httputil"
+	"log"
+	"net/http"
+	"net/http/httputil"
 
-    BA "github.com/darkhelmet/balance/backends"
-    "github.com/gonuts/commander"
+	BA "github.com/darkhelmet/balance/backends"
+	"github.com/gonuts/commander"
 )
 
 func httpBalance(bind string, backends BA.Backends) error {
-    log.Println("using http balancing")
-    proxy := &Proxy{
-        &httputil.ReverseProxy{Director: func(req *http.Request) {
-            backend := backends.Choose()
-            if backend == nil {
-                log.Printf("no backend for client %s", req.RemoteAddr)
-                panic(NoBackend{})
-            }
-            req.URL.Scheme = "http"
-            req.URL.Host = backend.String()
-            req.Header.Add(XRealIP, RealIP(req))
-        }},
-    }
-    log.Printf("listening on %s, balancing %d backends", bind, backends.Len())
-    return http.ListenAndServe(bind, proxy)
+	log.Println("using http balancing")
+	proxy := &Proxy{
+		&httputil.ReverseProxy{Director: func(req *http.Request) {
+			backend := backends.Choose()
+			if backend == nil {
+				log.Printf("no backend for client %s", req.RemoteAddr)
+				panic(NoBackend{})
+			}
+			req.URL.Scheme = "http"
+			req.URL.Host = backend.String()
+			req.Header.Add(XRealIP, RealIP(req))
+		}},
+	}
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
+	log.Printf("listening on %s, balancing %d backends", bind, backends.Len())
+	return http.ListenAndServe(bind, proxy)
 }
 
 func init() {
-    fs := newFlagSet("http")
+	fs := newFlagSet("http")
 
-    cmd.Subcommands = append(cmd.Subcommands, &commander.Command{
-        UsageLine: "http [options] [<backends>]",
-        Short:     "performs http based load balancing",
-        Flag:      *fs,
-        Run:       balancer(httpBalance),
-    })
+	cmd.Subcommands = append(cmd.Subcommands, &commander.Command{
+		UsageLine: "http [options] [<backends>]",
+		Short:     "performs http based load balancing",
+		Flag:      *fs,
+		Run:       balancer(httpBalance),
+	})
 }

--- a/https.go
+++ b/https.go
@@ -1,53 +1,54 @@
 package main
 
 import (
-    "log"
-    "net/http"
-    "net/http/httputil"
+	"log"
+	"net/http"
+	"net/http/httputil"
 
-    BA "github.com/darkhelmet/balance/backends"
-    "github.com/gonuts/commander"
+	BA "github.com/darkhelmet/balance/backends"
+	"github.com/gonuts/commander"
 )
 
 var (
-    httpsOptions = struct {
-        certFile, keyFile string
-    }{}
+	httpsOptions = struct {
+		certFile, keyFile string
+	}{}
 )
 
 func httpsBalance(bind string, backends BA.Backends) error {
-    if httpsOptions.certFile == "" || httpsOptions.keyFile == "" {
-        log.Fatalln("specify both -cert and -key")
-    }
+	if httpsOptions.certFile == "" || httpsOptions.keyFile == "" {
+		log.Fatalln("specify both -cert and -key")
+	}
 
-    log.Println("using https balancing")
+	log.Println("using https balancing")
 
-    proxy := &Proxy{
-        &httputil.ReverseProxy{Director: func(req *http.Request) {
-            backend := backends.Choose()
-            if backend == nil {
-                log.Printf("no backend for client %s", req.RemoteAddr)
-                panic(NoBackend{})
-            }
-            req.URL.Scheme = "http"
-            req.Header.Add("X-Forwarded-Proto", "https")
-            req.URL.Host = backend.String()
-            req.Header.Add(XRealIP, RealIP(req))
-        }},
-    }
-    log.Printf("listening on %s, balancing %d backends", bind, backends.Len())
-    return http.ListenAndServeTLS(bind, httpsOptions.certFile, httpsOptions.keyFile, proxy)
+	proxy := &Proxy{
+		&httputil.ReverseProxy{Director: func(req *http.Request) {
+			backend := backends.Choose()
+			if backend == nil {
+				log.Printf("no backend for client %s", req.RemoteAddr)
+				panic(NoBackend{})
+			}
+			req.URL.Scheme = "http"
+			req.Header.Add("X-Forwarded-Proto", "https")
+			req.URL.Host = backend.String()
+			req.Header.Add(XRealIP, RealIP(req))
+		}},
+	}
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
+	log.Printf("listening on %s, balancing %d backends", bind, backends.Len())
+	return http.ListenAndServeTLS(bind, httpsOptions.certFile, httpsOptions.keyFile, proxy)
 }
 
 func init() {
-    fs := newFlagSet("https")
-    fs.StringVar(&httpsOptions.certFile, "cert", "", "the SSL certificate file to use")
-    fs.StringVar(&httpsOptions.keyFile, "key", "", "the SSL key file to use")
+	fs := newFlagSet("https")
+	fs.StringVar(&httpsOptions.certFile, "cert", "", "the SSL certificate file to use")
+	fs.StringVar(&httpsOptions.keyFile, "key", "", "the SSL key file to use")
 
-    cmd.Subcommands = append(cmd.Subcommands, &commander.Command{
-        UsageLine: "https [options] <backend> [<more backends>]",
-        Short:     "performs https based load balancing",
-        Flag:      *fs,
-        Run:       balancer(httpsBalance),
-    })
+	cmd.Subcommands = append(cmd.Subcommands, &commander.Command{
+		UsageLine: "https [options] <backend> [<more backends>]",
+		Short:     "performs https based load balancing",
+		Flag:      *fs,
+		Run:       balancer(httpsBalance),
+	})
 }


### PR DESCRIPTION
The change is on line 26 (http.go) and 38 (https.go)
```
http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
```
(Due to go fmt, this intents with tabs instead of spaces.)

Before the fix there were 10% 502 errors with this test. And now, no errors:
```
./bombardier-linux-amd64 -c 1000 -n 100000 --cert server.crt --key server.key -k 'https://host/rest'
Bombarding https://host/rest with 100000 request(s) using 1000 connection(s)
 100000 / 100000 [=================] 100.00% 15s
Done!

Statistics        Avg      Stdev        Max
  Reqs/sec      7220.41    5850.36  128270.91
  Latency      147.56ms   459.61ms      6.98s
  HTTP codes:
    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     2.71MB
```